### PR TITLE
fixed unwanted scrolling when formatter is applied

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,6 +18,7 @@ function init(editor, onSave) {
 		return;
 	}
 
+	var cursorPosition = editor.getCursorBufferPosition();
 	var line = editor.getFirstVisibleScreenRow();
 
 	if (selectedText) {
@@ -25,6 +26,8 @@ function init(editor, onSave) {
 	} else {
 		editor.setText(retText);
 	}
+
+	editor.setCursorBufferPosition(cursorPosition);
 
 	if (editor.getScreenLineCount() < line){
 		return;

--- a/index.js
+++ b/index.js
@@ -26,10 +26,11 @@ function init(editor, onSave) {
 		editor.setText(retText);
 	}
 
-	if(editor.getScreenLineCount() < line){
+	if (editor.getScreenLineCount() < line){
 		return;
 	}
-	editor.scrollToScreenPosition([line + 2,0]);
+	
+	editor.scrollToScreenPosition([line + 2, 0]);
 }
 
 exports.config = {

--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ function init(editor, onSave) {
 		return;
 	}
 
-	var cursorPosition = editor.getCursorBufferPosition();
+	var line = editor.getFirstVisibleScreenRow();
 
 	if (selectedText) {
 		editor.setTextInBufferRange(editor.getSelectedBufferRange(), retText);
@@ -26,7 +26,10 @@ function init(editor, onSave) {
 		editor.setText(retText);
 	}
 
-	editor.setCursorBufferPosition(cursorPosition);
+	if(editor.getScreenLineCount() < line){
+		return;
+	}
+	editor.scrollToScreenPosition([line + 2,0]);
 }
 
 exports.config = {


### PR DESCRIPTION
When formatter is applied, the editor is often scrolled to unexpected position.
This patch will reduce number of scrolled lines to minimum.