### PR TITLE
fixed error when formatting very small files

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ function init(editor, onSave) {
 	}
 
 	var cursorPosition = editor.getCursorBufferPosition();
-	var line = editor.getFirstVisibleScreenRow();
+	var line = editor.getFirstVisibleScreenRow() + editor.displayBuffer.getVerticalScrollMargin();
 
 	if (selectedText) {
 		editor.setTextInBufferRange(editor.getSelectedBufferRange(), retText);
@@ -29,8 +29,8 @@ function init(editor, onSave) {
 
 	editor.setCursorBufferPosition(cursorPosition);
 
-	if (editor.getScreenLineCount() >= line) {
-		editor.scrollToScreenPosition([line + 2, 0]);
+	if (editor.getScreenLineCount() > line) {
+		editor.scrollToScreenPosition([line, 0]);
 	}
 }
 


### PR DESCRIPTION
Previous change of scrolling is causing error when file has less than 2 lines. This prevents scrolling on such files and also replaces hardcoded 2 with verticalScrollMargin variable.