### PR TITLE
chore: version bump esformatter-jsx to 4.0.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "esformatter-eol-last": "^1.0.0",
     "esformatter-ignore": "^0.1.3",
     "esformatter-jquery-chain": "^1.1.0",
-    "esformatter-jsx": "^2.0.10",
+    "esformatter-jsx": "^4.0.6",
     "esformatter-literal-notation": "^1.0.0",
     "esformatter-parseint": "^1.0.1",
     "esformatter-quote-props": "^1.0.2",


### PR DESCRIPTION
Updated to a more recent version of esformatter-jsx.  Perhaps for libraries that change more frequently it's better to leave them as global installs.