### PR TITLE
Upgrade to esformatter 0.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "style"
   ],
   "dependencies": {
-    "esformatter": "^0.8.1",
+    "esformatter": "^0.9.0",
     "esformatter-add-trailing-commas": "^1.1.0",
     "esformatter-braces": "^1.0.0",
     "esformatter-collapse-objects": "^0.5.1",


### PR DESCRIPTION
esformatter-flow requires esformatter 0.9

Sorry this should have been part of the last pull request, i've only just discovered how to test atom packages with apm link

After the upgrade to esformatter 0.9 flow works as expected, jsx plugin works as well but i've not tested any of the other plugins.