### PR TITLE
Attempt to get esformatter module from the project directory.

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,13 +7,13 @@ const SUPPORTED_SCOPES = [
 ];
 
 function esformatterModulePath(editor) {
-	let path = require('path');
-	let fs = require('fs');
+	const path = require('path');
+	const fs = require('fs');
 
 	const editorPath = editor.getPath();
 	const projectPath = atom.project.relativizePath(editorPath)[0];
 
-	if (projectPath != null) {
+	if (projectPath !== null) {
 		try {
 			const esformatterPath = path.join(projectPath, "node_modules/esformatter");
 			fs.accessSync(esformatterPath);
@@ -32,7 +32,7 @@ function init(editor, onSave) {
 		return;
 	}
 
-	let esformatter = require(esformatterModulePath(editor));
+	const esformatter = require(esformatterModulePath(editor));
 
 	const selectedText = onSave ? null : editor.getSelectedText();
 	const text = selectedText || editor.getText();

--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
 /** @babel */
-import esformatter from 'esformatter';
 
 const SUPPORTED_SCOPES = [
 	'source.js',
@@ -7,10 +6,33 @@ const SUPPORTED_SCOPES = [
 	'source.js.jsx'
 ];
 
+function esformatterModulePath(editor) {
+	let path = require('path');
+	let fs = require('fs');
+
+	const editorPath = editor.getPath();
+	const projectPath = atom.project.relativizePath(editorPath)[0];
+
+	if (projectPath != null) {
+		try {
+			const esformatterPath = path.join(projectPath, "node_modules/esformatter");
+			fs.accessSync(esformatterPath);
+			return esformatterPath;
+		} catch (err) {
+			console.error(err);
+		}
+	}
+
+	console.log('Could not find esformatter module in the project. Falling back to internal esformatter shipped with package.');
+	return 'esformatter';
+}
+
 function init(editor, onSave) {
 	if (!editor) {
 		return;
 	}
+
+	let esformatter = require(esformatterModulePath(editor));
 
 	const selectedText = onSave ? null : editor.getSelectedText();
 	const text = selectedText || editor.getText();


### PR DESCRIPTION
Attempts to get esformatter module from the project directory. If module not found in project, fallback to using the bundled version.

The benefits of this approach are:

1. The same esformatter version can be used regardless of whether I use atom, another text editor or call it from the console.
2. Upgrades to esformatter and upgrades/installs of new plugins can be done quicker since I can continue to use `npm install` and don't have to create a PR.
3. If I have a project that relies on a specific version of esformatter and plugin I can easily control this via `npm`.
