### PR TITLE
Added esformatter-asi plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "esformatter": "^0.9.0",
     "esformatter-add-trailing-commas": "^1.1.0",
     "esformatter-align": "^0.1.0",
+    "esformatter-asi": "^0.5.2",
     "esformatter-braces": "^1.0.0",
     "esformatter-collapse-objects": "^0.5.1",
     "esformatter-dot-notation": "^1.1.0",


### PR DESCRIPTION
[This plugin](https://github.com/nathanboktae/esformatter-asi) strips not required semicolons from the code.